### PR TITLE
Bump AssemblyScript version to v0.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,29 @@
 {
   "name": "as-covers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "as-covers",
-      "version": "0.1.0",
-      "hasInstallScript": true,
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/chalk": "^2.2.0",
+        "@types/line-column": "^1.0.0",
         "@types/node": "^18.11.9",
+        "@types/table": "^6.3.2",
         "@types/text-table": "^0.2.2",
         "chalk": "^5.1.2",
+        "csv-stringify": "^6.2.1",
         "micromatch": "^4.0.5",
         "table": "^6.8.1",
+        "visitor-as": "^0.11.3",
         "yaml": "^2.1.3"
       },
       "devDependencies": {
-        "@assemblyscript/loader": "^0.23.1",
-        "assemblyscript": "^0.23.1",
+        "@assemblyscript/loader": "^0.24.0",
+        "assemblyscript": "^0.24.0",
         "blessed": "^0.1.81",
         "colors": "^1.4.0",
         "lerna": "^6.0.3",
@@ -31,9 +34,9 @@
       }
     },
     "node_modules/@assemblyscript/loader": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.23.1.tgz",
-      "integrity": "sha512-gqtxYH4ZAOqG01IHqI4/r+JjVj0XldyHCq+zhNdvMwjGbrOz1hkuFj+h4PNdllf0PZiJogtxj3HJpyQCM3+9qg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.24.0.tgz",
+      "integrity": "sha512-IMDuChltU2uiCPZP3JT701tEz3wAJ5obfjyw5DFQw94D7KziGiooBnCc+Bkyyox9AmzitqwGqsZnWEGt49GQ8A==",
       "dev": true
     },
     "node_modules/@babel/code-frame": {
@@ -1988,6 +1991,11 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/line-column": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/line-column/-/line-column-1.0.0.tgz",
+      "integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w=="
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2016,6 +2024,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/table": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@types/table/-/table-6.3.2.tgz",
+      "integrity": "sha512-GJ82z3vQbx2BhiUo12w2A3lyBpXPJrGHjQ7iS5aH925098w8ojqiWBhgOUy97JS2PKLmRCTLT0sI+gJI4futig==",
+      "deprecated": "This is a stub types definition. table provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "table": "*"
+      }
     },
     "node_modules/@types/text-table": {
       "version": "0.2.2",
@@ -2290,10 +2307,9 @@
       "dev": true
     },
     "node_modules/assemblyscript": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.23.1.tgz",
-      "integrity": "sha512-D6n9s5x2Ll8I0e6rYfs/ZvHINcZrBPUfgwC10cXwyNxnvE3aJ+uiXlUQypMxPfo0LON2QKjDLvLkem+UMB1XCg==",
-      "dev": true,
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.24.0.tgz",
+      "integrity": "sha512-hSJg2z2nGCRdrw6KzG75oK+7TI+EFJ539PFcM6P2jY0GfwllgbmCarCm3PtkRBMMTFWUU0MWzIEVc/b5L6wIgw==",
       "dependencies": {
         "binaryen": "110.0.0-nightly.20221105",
         "long": "^5.2.0"
@@ -2422,7 +2438,6 @@
       "version": "110.0.0-nightly.20221105",
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0-nightly.20221105.tgz",
       "integrity": "sha512-OBESOc51q3SwgG8Uv8nMzGnSq7LJpSB/Fu8B3AjlZg6YtCEwRnlDWlnwNB6mdql+VdexfKmNcsrs4K7MYidmdQ==",
-      "dev": true,
       "bin": {
         "wasm-opt": "bin/wasm-opt",
         "wasm2js": "bin/wasm2js"
@@ -3072,6 +3087,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.1.tgz",
+      "integrity": "sha512-+DT/YEgqRy82aMPMA7yUUpFJPx9X8iZy7UhfyTE2bHmFJcjDiz1j29wzTFkYTtuNVceNgz8efsjICch+O1WcLQ=="
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -5373,6 +5393,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -5473,8 +5498,7 @@
     "node_modules/long": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/lru-cache": {
       "version": "7.14.1",
@@ -8481,6 +8505,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.2.tgz",
+      "integrity": "sha512-zvHx3VM83m2WYCE8XL99uaM7mFwYSkjR2OZti98fabHrwkjsCvgwChda5xctein3xGOyaQhtTeDq/1H/GNvF3A=="
+    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -8723,6 +8752,18 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/visitor-as": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/visitor-as/-/visitor-as-0.11.3.tgz",
+      "integrity": "sha512-5dUn/URe/Ky2gPBFj+a5teKcGgWoOfpNiJ0ApGWBbrGWVZC/Nf8ATuCeeEGqMNFfzqhmqe6e68/dSHYiSYTDJw==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "ts-mixer": "^6.0.2"
+      },
+      "peerDependencies": {
+        "assemblyscript": "^0.24.0"
       }
     },
     "node_modules/walk-up-path": {
@@ -9086,9 +9127,9 @@
   },
   "dependencies": {
     "@assemblyscript/loader": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.23.1.tgz",
-      "integrity": "sha512-gqtxYH4ZAOqG01IHqI4/r+JjVj0XldyHCq+zhNdvMwjGbrOz1hkuFj+h4PNdllf0PZiJogtxj3HJpyQCM3+9qg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.24.0.tgz",
+      "integrity": "sha512-IMDuChltU2uiCPZP3JT701tEz3wAJ5obfjyw5DFQw94D7KziGiooBnCc+Bkyyox9AmzitqwGqsZnWEGt49GQ8A==",
       "dev": true
     },
     "@babel/code-frame": {
@@ -10654,6 +10695,11 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/line-column": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/line-column/-/line-column-1.0.0.tgz",
+      "integrity": "sha512-wbw+IDRw/xY/RGy+BL6f4Eey4jsUgHQrMuA4Qj0CSG3x/7C2Oc57pmRoM2z3M4DkylWRz+G1pfX06sCXQm0J+w=="
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -10682,6 +10728,14 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/table": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@types/table/-/table-6.3.2.tgz",
+      "integrity": "sha512-GJ82z3vQbx2BhiUo12w2A3lyBpXPJrGHjQ7iS5aH925098w8ojqiWBhgOUy97JS2PKLmRCTLT0sI+gJI4futig==",
+      "requires": {
+        "table": "*"
+      }
     },
     "@types/text-table": {
       "version": "0.2.2",
@@ -10897,10 +10951,9 @@
       "dev": true
     },
     "assemblyscript": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.23.1.tgz",
-      "integrity": "sha512-D6n9s5x2Ll8I0e6rYfs/ZvHINcZrBPUfgwC10cXwyNxnvE3aJ+uiXlUQypMxPfo0LON2QKjDLvLkem+UMB1XCg==",
-      "dev": true,
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.24.0.tgz",
+      "integrity": "sha512-hSJg2z2nGCRdrw6KzG75oK+7TI+EFJ539PFcM6P2jY0GfwllgbmCarCm3PtkRBMMTFWUU0MWzIEVc/b5L6wIgw==",
       "requires": {
         "binaryen": "110.0.0-nightly.20221105",
         "long": "^5.2.0"
@@ -10989,8 +11042,7 @@
     "binaryen": {
       "version": "110.0.0-nightly.20221105",
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-110.0.0-nightly.20221105.tgz",
-      "integrity": "sha512-OBESOc51q3SwgG8Uv8nMzGnSq7LJpSB/Fu8B3AjlZg6YtCEwRnlDWlnwNB6mdql+VdexfKmNcsrs4K7MYidmdQ==",
-      "dev": true
+      "integrity": "sha512-OBESOc51q3SwgG8Uv8nMzGnSq7LJpSB/Fu8B3AjlZg6YtCEwRnlDWlnwNB6mdql+VdexfKmNcsrs4K7MYidmdQ=="
     },
     "bl": {
       "version": "4.1.0",
@@ -11490,6 +11542,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "csv-stringify": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.1.tgz",
+      "integrity": "sha512-+DT/YEgqRy82aMPMA7yUUpFJPx9X8iZy7UhfyTE2bHmFJcjDiz1j29wzTFkYTtuNVceNgz8efsjICch+O1WcLQ=="
     },
     "dargs": {
       "version": "7.0.0",
@@ -13223,6 +13280,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
@@ -13298,8 +13360,7 @@
     "long": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "lru-cache": {
       "version": "7.14.1",
@@ -15538,6 +15599,11 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
+    "ts-mixer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.2.tgz",
+      "integrity": "sha512-zvHx3VM83m2WYCE8XL99uaM7mFwYSkjR2OZti98fabHrwkjsCvgwChda5xctein3xGOyaQhtTeDq/1H/GNvF3A=="
+    },
     "ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -15716,6 +15782,15 @@
       "dev": true,
       "requires": {
         "builtins": "^5.0.0"
+      }
+    },
+    "visitor-as": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/visitor-as/-/visitor-as-0.11.3.tgz",
+      "integrity": "sha512-5dUn/URe/Ky2gPBFj+a5teKcGgWoOfpNiJ0ApGWBbrGWVZC/Nf8ATuCeeEGqMNFfzqhmqe6e68/dSHYiSYTDJw==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "ts-mixer": "^6.0.2"
       }
     },
     "walk-up-path": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "as-covers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Code coverage transform for AssemblyScript",
   "main": "index.js",
   "type": "module",
@@ -19,8 +19,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@assemblyscript/loader": "^0.23.1",
-    "assemblyscript": "^0.23.1",
+    "@assemblyscript/loader": "^0.24.0",
+    "assemblyscript": "^0.24.0",
     "blessed": "^0.1.81",
     "colors": "^1.4.0",
     "lerna": "^6.0.3",

--- a/packages/assembly/package.json
+++ b/packages/assembly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@as-covers/assembly",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AssemblyScript code coverage for as-covers",
   "scripts": {},
   "author": "Joshua Tenner <tenner.joshua@gmail.com>",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@as-covers/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Core code coverage package for as-covers.",
   "main": "index.js",
   "scripts": {},

--- a/packages/glue/package.json
+++ b/packages/glue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@as-covers/glue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Glue code for code coverage using node.js",
   "main": "lib/index.js",
   "type": "module",
@@ -18,7 +18,7 @@
     "table": "^6.8.1"
   },
   "devDependencies": {
-    "@assemblyscript/loader": "^0.23.1",
+    "@assemblyscript/loader": "^0.24.0",
     "@types/table": "^6.3.2"
   },
   "files": [

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@as-covers/transform",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The transform that enables code coverage for assemblyscript",
   "main": "lib/index.js",
   "type": "module",
@@ -13,16 +13,14 @@
     "Jairus Tanaka <jairus.v.tanaka@outlook.com>"
   ],
   "license": "MIT",
-  "peerDependencies": {
-    "assemblyscript": "^0.23.1"
-  },
   "devDependencies": {
     "@types/line-column": "^1.0.0",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "assemblyscript": "^0.24.0"
   },
   "dependencies": {
     "line-column": "^1.0.2",
-    "visitor-as": "^0.11.2"
+    "visitor-as": "^0.11.3"
   },
   "files": [
     "lib"


### PR DESCRIPTION
AssemblyScript v0.24.0 has been released, so this package needs to be bumped to that version. Also, the peer dependency in the transform package is now a dev dependency.